### PR TITLE
add channel filter description for subtitle search

### DIFF
--- a/mkdocs/docs/search.md
+++ b/mkdocs/docs/search.md
@@ -67,8 +67,10 @@ Narrow down your search with these secondary keywords:
 
 - `lang`: Search for matches only within a language. Use the same two letter ISO 639 language code as you have set on the settings page.
 - `source`: Can either be *auto* to search through auto generated subtitles only or *user* to search through user uploaded subtitles only.
+- `channel`: Limit subtitle search to a specific channel name. Useful to filter subtitle segments belonging only to one creator or channel.
 
 **Example**:
 
 - `full:contribute to open source lang:en` search for subtitle segments matching with the words *Contribute*, *to*, *Open* or *Source* in the language *en*.
 - `full:flight simulator cockpit source:user` to search for the words *Flight*, *Simulator* or *Cockpit* from *user* uploaded subtitle segments.
+- `full:javascript channel:corey schafer` to search for subtitles containing *javascript* from *Corey Schafer’s* channel only.


### PR DESCRIPTION
### Summary
This pull request updates the **Search Page** documentation to include information about the new `channel:`  keyword for full text (subtitle) searches.

The functionality was already added ([see previous PR](https://github.com/tubearchivist/tubearchivist/pull/1096)).  

---

### Changes
- Added description of the `channel:` keyword under the **Full** search section.
- Included an example query illustrating how to limit subtitle searches to a specific channel.

